### PR TITLE
feat: resume watching, per-episode subs, on-demand enrichment

### DIFF
--- a/client/src/components/MovieDetail.vue
+++ b/client/src/components/MovieDetail.vue
@@ -29,9 +29,19 @@
                                 @click="selectedQuality = q"
                             >{{ q }}</button>
                         </div>
+                        <button v-if="resumeTarget" class="btn-play-large btn-resume" @click="playResume">
+                            <RotateCcw :size="22" />
+                            <span>
+                                Resume
+                                <template v-if="resumeTarget.type === 'episode'">
+                                    S{{ resumeTarget.season }}E{{ resumeTarget.episode }}
+                                </template>
+                                <span class="resume-time">from {{ formatRemaining(resumeTarget.progress) }}</span>
+                            </span>
+                        </button>
                         <button class="btn-play-large" @click="playDefault">
                             <Play :size="24" />
-                            {{ movie.contentType === 'series' && firstEpisode ? `Play S${firstEpisode.season}E${firstEpisode.episode}` : 'Play' }}
+                            {{ resumeTarget ? 'Start Over' : (movie.contentType === 'series' && firstEpisode ? `Play S${firstEpisode.season}E${firstEpisode.episode}` : 'Play') }}
                         </button>
                     </div>
                 </div>
@@ -88,12 +98,16 @@
                                 <span v-if="ep.rating" class="ep-rating"><Star :size="11" /> {{ ep.rating }}</span>
                             </h3>
                             <p v-if="ep.released" class="ep-desc">{{ formatDate(ep.released) }}</p>
+                            <div v-if="episodeProgress(selectedSeason, ep.episodeNumber)" class="ep-progress">
+                                <div class="ep-progress-bar" :style="{ width: episodeProgressPct(selectedSeason, ep.episodeNumber) + '%' }"></div>
+                            </div>
                             <div v-if="ep.qualities && ep.qualities.length" class="ep-qualities">
                                 <span v-for="q in ep.qualities" :key="q" class="quality-tag">{{ q }}</span>
                             </div>
                         </div>
                     </div>
-                    <Play v-if="ep.hasMagnet" :size="18" class="ep-play-icon" />
+                    <RotateCcw v-if="ep.hasMagnet && episodeProgress(selectedSeason, ep.episodeNumber)" :size="18" class="ep-play-icon" />
+                    <Play v-else-if="ep.hasMagnet" :size="18" class="ep-play-icon" />
                     <span v-else class="ep-unavailable">No source</span>
                 </div>
 
@@ -128,11 +142,12 @@
 
 <script>
 import Api from '@/services/Api';
-import { ArrowLeft, Play, User, Tv, Download, Star } from 'lucide-vue-next';
+import { getProgress, clearProgress, formatTime } from '@/services/ProgressService';
+import { ArrowLeft, Play, User, Tv, Download, Star, RotateCcw } from 'lucide-vue-next';
 
 export default {
     name: 'MovieDetail',
-    components: { ArrowLeft, Play, User, Tv, Download, Star },
+    components: { ArrowLeft, Play, User, Tv, Download, Star, RotateCcw },
     data() {
         return {
             movie: null,
@@ -140,6 +155,7 @@ export default {
             newComment: '',
             selectedSeason: 1,
             selectedQuality: null,
+            progressTick: 0,
         };
     },
     computed: {
@@ -158,6 +174,30 @@ export default {
             if (s.hasMagnet) return { season: s.seasonNumber, episode: null };
             return null;
         },
+        movieProgress() {
+            // progressTick is referenced to trigger recompute on localStorage changes
+            this.progressTick; // eslint-disable-line no-unused-expressions
+            if (!this.movie || this.movie.contentType === 'series') return null;
+            return getProgress(this.movie._id);
+        },
+        resumeTarget() {
+            // For series, resume the most recently watched episode if any
+            this.progressTick; // eslint-disable-line no-unused-expressions
+            if (!this.movie) return null;
+            if (this.movie.contentType !== 'series') {
+                return this.movieProgress ? { type: 'movie', progress: this.movieProgress } : null;
+            }
+            let best = null;
+            for (const season of (this.movie.seasons || [])) {
+                for (const ep of (season.episodes || [])) {
+                    const p = getProgress(this.movie._id, season.seasonNumber, ep.episodeNumber);
+                    if (p && (!best || p.updatedAt > best.progress.updatedAt)) {
+                        best = { type: 'episode', season: season.seasonNumber, episode: ep.episodeNumber, progress: p };
+                    }
+                }
+            }
+            return best;
+        },
         availableQualities() {
             if (this.movie?.qualities?.length) return this.movie.qualities;
             if (this.currentSeasonData) {
@@ -174,6 +214,13 @@ export default {
     },
     methods: {
         playDefault() {
+            // If user chose "Start Over" (resume exists), clear the target's saved position first
+            if (this.resumeTarget) {
+                const r = this.resumeTarget;
+                if (r.type === 'movie') clearProgress(this.movie._id);
+                else clearProgress(this.movie._id, r.season, r.episode);
+                this.progressTick++;
+            }
             if (this.movie.contentType === 'series' && this.firstEpisode) {
                 if (this.firstEpisode.episode) this.playEpisode(this.firstEpisode.season, this.firstEpisode.episode);
                 else this.playSeason(this.firstEpisode.season);
@@ -194,6 +241,25 @@ export default {
             const query = { season };
             if (this.selectedQuality) query.quality = this.selectedQuality;
             this.$router.push({ name: 'Watch', params: { id: this.movie._id }, query });
+        },
+        episodeProgress(season, episode) {
+            this.progressTick; // eslint-disable-line no-unused-expressions
+            return getProgress(this.movie._id, season, episode);
+        },
+        episodeProgressPct(season, episode) {
+            const p = this.episodeProgress(season, episode);
+            if (!p?.duration) return 0;
+            return Math.min(100, (p.position / p.duration) * 100);
+        },
+        playResume() {
+            const r = this.resumeTarget;
+            if (!r) return;
+            if (r.type === 'movie') this.playMovie();
+            else this.playEpisode(r.season, r.episode);
+        },
+        formatRemaining(progress) {
+            if (!progress) return '';
+            return formatTime(progress.position);
         },
         formatDate(d) {
             if (!d || d === 'N/A') return '';
@@ -242,8 +308,10 @@ export default {
 .genres-text { color: #888; }
 .detail-summary { color: #ccc; font-size: 0.9rem; line-height: 1.5; margin-bottom: 20px; max-width: 550px; }
 .detail-actions { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
-.btn-play-large { display: inline-flex; align-items: center; gap: 8px; background: #fff; color: #000; border: none; border-radius: 4px; padding: 11px 32px; font-size: 1.1rem; font-weight: 700; cursor: pointer; transition: opacity 0.2s; }
+.btn-play-large { display: inline-flex; align-items: center; gap: 8px; background: #fff; color: #000; border: none; border-radius: 4px; padding: 11px 24px; font-size: 1.05rem; font-weight: 700; cursor: pointer; transition: opacity 0.2s; }
 .btn-play-large:hover { opacity: 0.85; }
+.btn-resume { background: #E50914; color: #fff; }
+.btn-resume .resume-time { display: block; font-size: 0.7rem; font-weight: 500; opacity: 0.85; margin-top: 1px; }
 
 /* Quality selector */
 .quality-group { display: flex; gap: 4px; }
@@ -282,6 +350,8 @@ export default {
 .ep-info h3 { color: #e5e5e5; font-size: 0.9rem; font-weight: 600; margin: 0 0 2px; display: flex; align-items: center; gap: 8px; }
 .ep-rating { color: #f5c518; font-size: 0.75rem; font-weight: 600; display: inline-flex; align-items: center; gap: 2px; }
 .ep-desc { color: #666; font-size: 0.78rem; margin: 0; }
+.ep-progress { width: 180px; height: 3px; background: #333; border-radius: 2px; margin-top: 6px; overflow: hidden; max-width: 100%; }
+.ep-progress-bar { height: 100%; background: #E50914; transition: width 0.3s; }
 .ep-qualities { display: flex; gap: 4px; margin-top: 4px; }
 .quality-tag { background: #222; color: #888; font-size: 0.65rem; padding: 1px 6px; border-radius: 2px; }
 .ep-play-icon { color: #999; flex-shrink: 0; transition: color 0.2s; }

--- a/client/src/components/Movies.vue
+++ b/client/src/components/Movies.vue
@@ -78,6 +78,28 @@
 
             <!-- Home: Category Rows -->
             <div v-else class="browse-rows">
+                <!-- Continue Watching -->
+                <div class="category-row" v-if="continueWatching.length > 0">
+                    <h2 class="row-title"><RotateCcw :size="18" /> Continue Watching</h2>
+                    <div class="row-container">
+                        <button class="scroll-btn scroll-left" @click="scrollRow($event, -1)"><ChevronLeft :size="24" /></button>
+                        <div class="row-movies">
+                            <div v-for="entry in continueWatching" :key="'cw-' + entry.movieId + (entry.season || '') + (entry.episode || '')" class="movie-card continue-card" @click="resumeProgress(entry)">
+                                <img v-if="entry.cover" :src="entry.cover" :alt="entry.title" class="movie-poster" loading="lazy" />
+                                <div v-else class="movie-poster-placeholder"><span>{{ entry.title }}</span></div>
+                                <span v-if="entry.contentType === 'series'" class="type-tag">TV</span>
+                                <button class="continue-close" @click.stop="removeProgress(entry)" title="Remove"><XIcon :size="14" /></button>
+                                <div class="continue-progress"><div class="continue-progress-bar" :style="{ width: progressPct(entry) + '%' }"></div></div>
+                                <div class="card-overlay continue-overlay">
+                                    <h3>{{ entry.title }}</h3>
+                                    <p v-if="entry.season != null">S{{ entry.season }}E{{ entry.episode }}</p>
+                                </div>
+                            </div>
+                        </div>
+                        <button class="scroll-btn scroll-right" @click="scrollRow($event, 1)"><ChevronRight :size="24" /></button>
+                    </div>
+                </div>
+
                 <!-- Recently Added -->
                 <div class="category-row" v-if="recentlyAdded.length > 0">
                     <h2 class="row-title"><Clock :size="18" /> Recently Added</h2>
@@ -140,13 +162,14 @@
 
 <script>
 import MoviesService from '@/services/MoviesService';
-import { Search, X, SearchX, Play, Info, ChevronLeft, ChevronRight, Film, Star, TrendingUp, Clock } from 'lucide-vue-next';
+import { getAllProgress, clearProgress } from '@/services/ProgressService';
+import { Search, X, SearchX, Play, Info, ChevronLeft, ChevronRight, Film, Star, TrendingUp, Clock, RotateCcw, X as XIcon } from 'lucide-vue-next';
 
 export default {
     name: 'BrowsePage',
-    components: { Search, X, SearchX, Play, Info, ChevronLeft, ChevronRight, Film, Star, TrendingUp, Clock },
+    components: { Search, X, SearchX, Play, Info, ChevronLeft, ChevronRight, Film, Star, TrendingUp, Clock, RotateCcw, XIcon },
     data() {
-        return { movies: [], loading: true, featuredMovie: null, searchQuery: '', searchActive: false, searching: false, searchDone: false, searchResults: [] };
+        return { movies: [], loading: true, featuredMovie: null, searchQuery: '', searchActive: false, searching: false, searchDone: false, searchResults: [], progressTick: 0 };
     },
     computed: {
         isFiltered() { return !!this.$route.query.type || !!this.$route.query.category; },
@@ -166,6 +189,10 @@ export default {
         trendingMovies() {
             return [...this.uniqueMovies].filter(m => m.cover).sort((a, b) => (b.seeds || 0) - (a.seeds || 0)).slice(0, 20);
         },
+        continueWatching() {
+            this.progressTick; // eslint-disable-line no-unused-expressions
+            return getAllProgress().slice(0, 15);
+        },
         moviesByCategory() {
             const cats = {};
             this.uniqueMovies.forEach(movie => {
@@ -183,6 +210,15 @@ export default {
     async mounted() {
         if (this.$route.query.q) { this.searchQuery = this.$route.query.q; this.searchActive = true; await this.searchTorrents(); }
         await this.fetchMovies();
+        this._refreshProgress = () => { this.progressTick++; };
+        window.addEventListener('focus', this._refreshProgress);
+        document.addEventListener('visibilitychange', this._refreshProgress);
+    },
+    beforeUnmount() {
+        if (this._refreshProgress) {
+            window.removeEventListener('focus', this._refreshProgress);
+            document.removeEventListener('visibilitychange', this._refreshProgress);
+        }
     },
     watch: {
         '$route.query.q'(q) { if (q) { this.searchQuery = q; this.searchActive = true; this.searchTorrents(); } },
@@ -218,6 +254,21 @@ export default {
         clearSearch() { this.searchQuery = ''; this.searchActive = false; this.searchResults = []; this.searchDone = false; },
         goToMovie(m) { this.$router.push({ name: 'MovieDetail', params: { id: m._id } }); },
         playMovie(m) { this.$router.push({ name: 'Watch', params: { id: m._id } }); },
+        resumeProgress(entry) {
+            const query = {};
+            if (entry.season != null) query.season = entry.season;
+            if (entry.episode != null) query.episode = entry.episode;
+            if (entry.quality) query.quality = entry.quality;
+            this.$router.push({ name: 'Watch', params: { id: entry.movieId }, query });
+        },
+        removeProgress(entry) {
+            clearProgress(entry.movieId, entry.season, entry.episode);
+            this.progressTick++;
+        },
+        progressPct(entry) {
+            if (!entry?.duration) return 0;
+            return Math.min(100, (entry.position / entry.duration) * 100);
+        },
         truncate(t, l) { return !t ? '' : t.length > l ? t.substring(0, l) + '...' : t; },
         scrollRow(e, d) { const c = e.target.closest('.row-container').querySelector('.row-movies'); c.scrollBy({ left: d * c.clientWidth * 0.75, behavior: 'smooth' }); },
     },
@@ -283,6 +334,15 @@ export default {
 .movie-card:hover .card-overlay { opacity: 1; }
 .card-overlay h3 { color: #fff; font-size: 0.78rem; font-weight: 700; margin: 0 0 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .card-overlay p { color: #999; font-size: 0.68rem; margin: 0; }
+
+/* Continue Watching card */
+.continue-card { position: relative; }
+.continue-close { position: absolute; top: 7px; right: 7px; z-index: 6; background: rgba(0,0,0,0.75); border: none; color: #fff; width: 22px; height: 22px; border-radius: 50%; cursor: pointer; display: none; align-items: center; justify-content: center; padding: 0; }
+.continue-card:hover .continue-close { display: flex; }
+.continue-close:hover { background: #E50914; }
+.continue-progress { position: absolute; bottom: 0; left: 0; right: 0; height: 3px; background: rgba(255,255,255,0.2); z-index: 5; }
+.continue-progress-bar { height: 100%; background: #E50914; }
+.continue-overlay { padding-bottom: 14px; }
 
 .loading-state { padding: 40px 4%; }
 .skeleton-row { margin-bottom: 36px; }

--- a/client/src/components/VideoPlayer.vue
+++ b/client/src/components/VideoPlayer.vue
@@ -40,6 +40,8 @@
                 :src="streamUrl"
                 @error="onVideoError"
                 @ended="onVideoEnded"
+                @loadedmetadata="onMetadataLoaded"
+                @timeupdate="onTimeUpdate"
             >
                 <track v-if="subtitles.en" kind="subtitles" :src="apiBase + subtitles.en" srclang="en" label="English" />
                 <track v-if="subtitles.fr" kind="subtitles" :src="apiBase + subtitles.fr" srclang="fr" label="French" />
@@ -73,7 +75,10 @@
 
 <script>
 import Api from '@/services/Api';
+import { saveProgress, getProgress, clearProgress } from '@/services/ProgressService';
 import { ArrowLeft, AlertCircle, Wifi, ArrowDown, HardDrive, Play, Star } from 'lucide-vue-next';
+
+const SAVE_INTERVAL_SECONDS = 5;
 
 export default {
     name: 'VideoPlayer',
@@ -91,9 +96,18 @@ export default {
             nextCountdown: 10,
             nextTimer: null,
             stats: { status: 'connecting', progress: 0, downloaded: 0, downloadedFormatted: '0 B', fileSize: 0, fileSizeFormatted: '0 B', speed: 0, speedFormatted: '0 B/s', peers: 0, fileName: '' },
+            lastSavedAt: 0,
         };
     },
     computed: {
+        routeSeason() {
+            const s = this.$route.query.season;
+            return s != null ? Number(s) : undefined;
+        },
+        routeEpisode() {
+            const e = this.$route.query.episode;
+            return e != null ? Number(e) : undefined;
+        },
         displayProgress() { return this.stats.progress || 0; },
         episodeLabel() {
             const s = this.$route.query.season;
@@ -140,6 +154,7 @@ export default {
     beforeUnmount() {
         if (this.pollTimer) clearInterval(this.pollTimer);
         if (this.nextTimer) clearInterval(this.nextTimer);
+        this.persistProgress();
     },
     methods: {
         buildQueryString() {
@@ -177,13 +192,49 @@ export default {
             } catch (err) { /* keep polling */ }
         },
         async loadSubtitles() {
-            try { const r = await Api().get(`subtitles/${this.$route.params.id}`); this.subtitles = r.data; }
-            catch (err) { /* optional */ }
+            try {
+                const params = new URLSearchParams();
+                if (this.$route.query.season) params.set('season', this.$route.query.season);
+                if (this.$route.query.episode) params.set('episode', this.$route.query.episode);
+                const qs = params.toString();
+                const r = await Api().get(`subtitles/${this.$route.params.id}${qs ? '?' + qs : ''}`);
+                this.subtitles = r.data;
+            } catch (err) { /* optional */ }
+        },
+        onMetadataLoaded() {
+            const saved = getProgress(this.$route.params.id, this.routeSeason, this.routeEpisode);
+            if (!saved || !this.$refs.video) return;
+            const duration = this.$refs.video.duration;
+            if (saved.position > 10 && (!duration || saved.position < duration - 30)) {
+                this.$refs.video.currentTime = saved.position;
+            }
+        },
+        onTimeUpdate() {
+            if (!this.$refs.video) return;
+            const now = Date.now();
+            if (now - this.lastSavedAt < SAVE_INTERVAL_SECONDS * 1000) return;
+            this.lastSavedAt = now;
+            this.persistProgress();
+        },
+        persistProgress() {
+            if (!this.$refs.video || !this.movie) return;
+            saveProgress({
+                movieId: this.$route.params.id,
+                season: this.routeSeason,
+                episode: this.routeEpisode,
+                position: this.$refs.video.currentTime,
+                duration: this.$refs.video.duration || null,
+                title: this.movie.title,
+                cover: this.movie.cover,
+                contentType: this.movie.contentType,
+                quality: this.$route.query.quality || null,
+            });
         },
         onVideoError() {
             if (this.ready) { this.error = 'Playback failed. Retrying...'; this.ready = false; this.startPrepare(); }
         },
         onVideoEnded() {
+            clearProgress(this.$route.params.id, this.routeSeason, this.routeEpisode);
             if (this.nextEpisode) {
                 this.showNextOverlay = true;
                 this.nextCountdown = 10;
@@ -202,7 +253,9 @@ export default {
             // Reset player state for new episode
             this.$nextTick(() => {
                 this.ready = false; this.streamUrl = null; this.error = null;
+                this.subtitles = { en: null, fr: null };
                 this.startPrepare();
+                this.loadSubtitles();
             });
         },
         goBack() {

--- a/client/src/services/ProgressService.js
+++ b/client/src/services/ProgressService.js
@@ -1,0 +1,66 @@
+const KEY_PREFIX = 'hypertube:progress:';
+const MAX_ENTRIES = 50;
+const MIN_POSITION_TO_SAVE = 10;
+const COMPLETION_THRESHOLD = 0.95;
+
+function buildKey(movieId, season, episode) {
+    let k = `${KEY_PREFIX}${movieId}`;
+    if (season != null) k += `:S${season}`;
+    if (episode != null) k += `:E${episode}`;
+    return k;
+}
+
+function pruneOldEntries() {
+    const items = getAllProgress();
+    if (items.length <= MAX_ENTRIES) return;
+    items.slice(MAX_ENTRIES).forEach((item) => {
+        localStorage.removeItem(buildKey(item.movieId, item.season, item.episode));
+    });
+}
+
+export function saveProgress(entry) {
+    if (!entry?.movieId || !entry.position || entry.position < MIN_POSITION_TO_SAVE) return;
+    if (entry.duration && entry.position / entry.duration >= COMPLETION_THRESHOLD) {
+        clearProgress(entry.movieId, entry.season, entry.episode);
+        return;
+    }
+    const key = buildKey(entry.movieId, entry.season, entry.episode);
+    const record = { ...entry, updatedAt: Date.now() };
+    try {
+        localStorage.setItem(key, JSON.stringify(record));
+        pruneOldEntries();
+    } catch (e) { /* quota — ignore */ }
+}
+
+export function getProgress(movieId, season, episode) {
+    try {
+        const raw = localStorage.getItem(buildKey(movieId, season, episode));
+        return raw ? JSON.parse(raw) : null;
+    } catch (e) { return null; }
+}
+
+export function clearProgress(movieId, season, episode) {
+    localStorage.removeItem(buildKey(movieId, season, episode));
+}
+
+export function getAllProgress() {
+    const items = [];
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (!key || !key.startsWith(KEY_PREFIX)) continue;
+        try {
+            const v = JSON.parse(localStorage.getItem(key));
+            if (v) items.push(v);
+        } catch (e) { /* corrupt — skip */ }
+    }
+    return items.sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+}
+
+export function formatTime(seconds) {
+    if (!seconds || seconds < 0) return '0:00';
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = Math.floor(seconds % 60);
+    if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+    return `${m}:${String(s).padStart(2, '0')}`;
+}

--- a/server/src/config/setup.js
+++ b/server/src/config/setup.js
@@ -103,7 +103,81 @@ const stopSeeding = () => {
     seedingActive = false;
 };
 
-// Enrich series with episode titles from OMDB (1 call per season)
+// Merge OMDB episode data into a season, preserving existing magnet/title/rating
+function mergeSeasonData(show, seasonNumber, episodeData) {
+    let season = show.seasons.find(x => x.seasonNumber === seasonNumber);
+    if (!season) {
+        show.seasons.push({ seasonNumber, magnet: [], episodes: [] });
+        season = show.seasons.find(x => x.seasonNumber === seasonNumber);
+    }
+    season.episodeCount = episodeData.length;
+
+    for (const epData of episodeData) {
+        let episode = season.episodes.find(e => e.episodeNumber === epData.episodeNumber);
+        if (!episode) {
+            season.episodes.push({
+                episodeNumber: epData.episodeNumber,
+                title: epData.title,
+                rating: epData.rating,
+                released: epData.released,
+                magnet: [],
+            });
+        } else {
+            if (!episode.title) episode.title = epData.title;
+            if (!episode.rating) episode.rating = epData.rating;
+            if (!episode.released) episode.released = epData.released;
+        }
+    }
+    season.episodes.sort((a, b) => a.episodeNumber - b.episodeNumber);
+}
+
+// Enrich a single series doc. Options:
+//   parallel: fetch all seasons concurrently (fast, for on-demand)
+//   interSeasonDelayMs: delay between sequential fetches (for background batch)
+//   maxSeasons: cap seasons fetched (defense against 30+ season shows on-demand)
+const enrichOneSeries = async (show, { parallel = false, interSeasonDelayMs = 400, maxSeasons = Infinity } = {}) => {
+    if (!ImdbService.isQuotaAvailable()) return false;
+
+    const numSeasons = show.totalSeasons || show.seasons.length || 0;
+    if (numSeasons === 0) return false;
+
+    const targetSeasons = Math.min(numSeasons, maxSeasons);
+    let anyEnriched = false;
+    let allFetched = true;
+
+    if (parallel) {
+        const fetches = [];
+        for (let s = 1; s <= targetSeasons; s++) {
+            fetches.push(ImdbService.fetchSeasonEpisodes(show.imdb_code, s).then(data => ({ s, data })));
+        }
+        const results = await Promise.all(fetches);
+        for (const { s, data } of results) {
+            if (!data) { allFetched = false; continue; }
+            mergeSeasonData(show, s, data);
+            anyEnriched = true;
+        }
+    } else {
+        for (let s = 1; s <= targetSeasons; s++) {
+            if (!ImdbService.isQuotaAvailable()) { allFetched = false; break; }
+            const data = await ImdbService.fetchSeasonEpisodes(show.imdb_code, s);
+            if (!data) { allFetched = false; continue; }
+            mergeSeasonData(show, s, data);
+            anyEnriched = true;
+            await new Promise((r) => setTimeout(r, interSeasonDelayMs));
+        }
+    }
+
+    if (anyEnriched) {
+        show.seasons.sort((a, b) => a.seasonNumber - b.seasonNumber);
+        if (allFetched && targetSeasons === numSeasons) {
+            show.episodesEnriched = true;
+        }
+        await show.save();
+    }
+    return anyEnriched;
+};
+
+// Background batch: enrich up to 10 un-enriched series (1 OMDB call per season)
 const enrichSeriesEpisodes = async () => {
     const Movie = require('../models/Movie');
 
@@ -121,52 +195,11 @@ const enrichSeriesEpisodes = async () => {
             console.log('Episode enrichment: OMDB quota exhausted');
             break;
         }
-
-        const numSeasons = show.totalSeasons || show.seasons.length || 0;
-        let enrichedAny = false;
-
-        for (let s = 1; s <= numSeasons; s++) {
-            if (!ImdbService.isQuotaAvailable()) break;
-
-            const episodeData = await ImdbService.fetchSeasonEpisodes(show.imdb_code, s);
-            if (!episodeData) continue;
-
-            let season = show.seasons.find(x => x.seasonNumber === s);
-            if (!season) {
-                show.seasons.push({ seasonNumber: s, magnet: [], episodes: [] });
-                season = show.seasons.find(x => x.seasonNumber === s);
-            }
-            season.episodeCount = episodeData.length;
-
-            for (const epData of episodeData) {
-                let episode = season.episodes.find(e => e.episodeNumber === epData.episodeNumber);
-                if (!episode) {
-                    season.episodes.push({
-                        episodeNumber: epData.episodeNumber,
-                        title: epData.title,
-                        rating: epData.rating,
-                        released: epData.released,
-                        magnet: [],
-                    });
-                } else {
-                    if (!episode.title) episode.title = epData.title;
-                    if (!episode.rating) episode.rating = epData.rating;
-                    if (!episode.released) episode.released = epData.released;
-                }
-            }
-            season.episodes.sort((a, b) => a.episodeNumber - b.episodeNumber);
-            enrichedAny = true;
-
-            await new Promise((r) => setTimeout(r, 400));
-        }
-
-        if (enrichedAny) {
-            show.seasons.sort((a, b) => a.seasonNumber - b.seasonNumber);
-            show.episodesEnriched = true;
-            await show.save();
-            console.log(`  Enriched episodes: ${show.title} (${numSeasons} seasons)`);
+        const enriched = await enrichOneSeries(show, { parallel: false });
+        if (enriched) {
+            console.log(`  Enriched episodes: ${show.title} (${show.totalSeasons || show.seasons.length} seasons)`);
         }
     }
 };
 
-module.exports = { startContinuousSeeding, stopSeeding, enrichSeriesEpisodes };
+module.exports = { startContinuousSeeding, stopSeeding, enrichSeriesEpisodes, enrichOneSeries };

--- a/server/src/routers/movie.js
+++ b/server/src/routers/movie.js
@@ -10,6 +10,8 @@ const OS = require('opensubtitles-api');
 const Config = require('../config/Config');
 const Movie = require('../models/Movie');
 const { showMovie } = require('../functions/movie');
+const { enrichOneSeries } = require('../config/setup');
+const ImdbService = require('../services/ImdbService');
 
 const OpenSubtitles = new OS({
     useragent: Config.opensubtitles.useragent,
@@ -317,6 +319,24 @@ router.get('/movie/:id', async (req, res) => {
         if (!movie) {
             return res.status(404).json({ error: 'Movie not found' });
         }
+
+        // On-demand episode enrichment: if a user opens a freshly-ingested series,
+        // fetch OMDB episode titles/ratings/dates synchronously so they don't see bare numbers.
+        // Parallel fetch, capped at 20 seasons to bound latency and quota use.
+        if (
+            movie.contentType === 'series' &&
+            !movie.episodesEnriched &&
+            movie.imdb_code &&
+            ImdbService.isQuotaAvailable()
+        ) {
+            try {
+                await enrichOneSeries(movie, { parallel: true, maxSeasons: 20 });
+            } catch (e) {
+                // Non-fatal — fall back to whatever metadata we already have
+                console.warn('On-demand enrichment failed:', e.message);
+            }
+        }
+
         const obj = movie.toObject();
 
         // Indicate magnet availability
@@ -367,12 +387,19 @@ router.get('/movie/:id', async (req, res) => {
 router.get('/subtitles/:id', async (req, res) => {
     try {
         const movie = await Movie.findById(req.params.id);
-        OpenSubtitles.search({
+        const season = req.query.season != null ? Number(req.query.season) : undefined;
+        const episode = req.query.episode != null ? Number(req.query.episode) : undefined;
+
+        const searchParams = {
             sublanguageid: ['fre', 'eng'].join(),
             extensions: 'srt',
             limit: 'all',
-            imdbid: movie.imdb_code
-        })
+            imdbid: movie.imdb_code,
+        };
+        if (Number.isFinite(season)) searchParams.season = season;
+        if (Number.isFinite(episode)) searchParams.episode = episode;
+
+        OpenSubtitles.search(searchParams)
             .then((subtitles) => {
                 const subtitlesPath = path.join(__dirname, 'subtitles');
                 if (!fs.existsSync(subtitlesPath)) {


### PR DESCRIPTION
- Resume Watching: localStorage-backed playback progress keyed by movie/season/episode; saves every 5s, restores on metadata load, clears at 95% watched. Adds a "Continue Watching" row on Browse and a red "Resume from HH:MM" button + per-episode progress bar on series detail.
- Per-episode subtitles: /subtitles/:id now accepts season/episode and forwards them to OpenSubtitles so subs match the playing episode instead of the series root.
- On-demand enrichment: GET /movie/:id synchronously fetches OMDB episode titles/ratings/dates (parallel, capped at 20 seasons) when opening a freshly-ingested series, so users don't see bare episode numbers while the background enrichment job catches up.