### PR TITLE
feat: smoother buffering UX — warm-up, backdrop, ETA

### DIFF
--- a/client/src/components/MovieDetail.vue
+++ b/client/src/components/MovieDetail.vue
@@ -143,6 +143,8 @@
 <script>
 import Api from '@/services/Api';
 import { getProgress, clearProgress, formatTime } from '@/services/ProgressService';
+
+let warmupInFlight = null;
 import { ArrowLeft, Play, User, Tv, Download, Star, RotateCcw } from 'lucide-vue-next';
 
 export default {
@@ -272,8 +274,33 @@ export default {
                 const response = await Api().get(`movie/${this.$route.params.id}`);
                 this.movie = response.data;
                 if (this.movie.seasons?.length) this.selectedSeason = this.movie.seasons[0].seasonNumber;
+                this.warmUpTorrent();
             } catch (err) { console.error('Failed to load:', err); }
             finally { this.loading = false; }
+        },
+        warmUpTorrent() {
+            if (!this.movie) return;
+            const params = new URLSearchParams();
+            if (this.movie.contentType === 'series') {
+                // Prefer the episode the user would see "Resume" on; fall back to first available
+                const resume = this.resumeTarget;
+                const target = resume?.type === 'episode'
+                    ? { season: resume.season, episode: resume.episode }
+                    : this.firstEpisode;
+                if (!target) return;
+                params.set('season', target.season);
+                if (target.episode) params.set('episode', target.episode);
+            } else if (!this.movie.hasMagnet) {
+                return;
+            }
+            if (this.selectedQuality) params.set('quality', this.selectedQuality);
+            const qs = params.toString();
+            const key = `${this.movie._id}?${qs}`;
+            if (warmupInFlight === key) return; // already warming this exact target
+            warmupInFlight = key;
+            Api().get(`prepare/${this.movie._id}${qs ? '?' + qs : ''}`)
+                .catch(() => {})
+                .finally(() => { if (warmupInFlight === key) warmupInFlight = null; });
         },
         async addComment() {
             if (!this.newComment.trim()) return;

--- a/client/src/components/VideoPlayer.vue
+++ b/client/src/components/VideoPlayer.vue
@@ -7,6 +7,8 @@
 
         <!-- Buffering -->
         <div v-if="!ready" class="player-loading">
+            <div v-if="movie?.cover" class="loading-backdrop" :style="{ backgroundImage: `url(${movie.cover})` }"></div>
+            <div class="loading-scrim"></div>
             <div v-if="error" class="loading-error">
                 <AlertCircle :size="48" color="#E50914" />
                 <p>{{ error }}</p>
@@ -95,8 +97,9 @@ export default {
             showNextOverlay: false,
             nextCountdown: 10,
             nextTimer: null,
-            stats: { status: 'connecting', progress: 0, downloaded: 0, downloadedFormatted: '0 B', fileSize: 0, fileSizeFormatted: '0 B', speed: 0, speedFormatted: '0 B/s', peers: 0, fileName: '' },
+            stats: { status: 'connecting', progress: 0, downloaded: 0, downloadedFormatted: '0 B', fileSize: 0, fileSizeFormatted: '0 B', speed: 0, speedFormatted: '0 B/s', peers: 0, fileName: '', bufferTarget: 0 },
             lastSavedAt: 0,
+            etaSmoothed: null,
         };
     },
     computed: {
@@ -117,13 +120,16 @@ export default {
             return '';
         },
         statusMessage() {
-            switch (this.stats.status) {
-                case 'connecting': return 'Finding peers...';
-                case 'buffering': return 'Buffering video...';
-                case 'ready': return 'Starting playback...';
-                default: return 'Preparing stream...';
+            if (this.stats.status === 'ready') return 'Starting playback...';
+            if (this.stats.peers === 0) return 'Finding peers...';
+            if (this.etaSeconds != null) {
+                if (this.etaSeconds <= 1) return 'Almost ready...';
+                return `Starting in ~${this.etaSeconds}s`;
             }
+            if (this.stats.status === 'buffering') return 'Buffering...';
+            return 'Preparing stream...';
         },
+        etaSeconds() { return this.etaSmoothed; },
         nextEpisode() {
             if (!this.movie || this.movie.contentType !== 'series' || !this.movie.seasons) return null;
             const s = Number(this.$route.query.season);
@@ -181,6 +187,7 @@ export default {
                 const qs = this.buildQueryString();
                 const response = await Api().get(`prepare/${this.$route.params.id}${qs}`);
                 this.stats = response.data;
+                this.updateEta();
                 if (this.stats.status === 'ready') {
                     clearInterval(this.pollTimer); this.pollTimer = null;
                     this.streamUrl = `${this.apiBase}/stream/${this.$route.params.id}${qs}`;
@@ -200,6 +207,17 @@ export default {
                 const r = await Api().get(`subtitles/${this.$route.params.id}${qs ? '?' + qs : ''}`);
                 this.subtitles = r.data;
             } catch (err) { /* optional */ }
+        },
+        updateEta() {
+            const { bufferTarget, downloaded, speed } = this.stats;
+            if (!bufferTarget || !speed || speed <= 0) {
+                this.etaSmoothed = null;
+                return;
+            }
+            const remaining = Math.max(0, bufferTarget - downloaded);
+            const raw = Math.max(1, Math.round(remaining / speed));
+            // Exponential smoothing to avoid flicker
+            this.etaSmoothed = this.etaSmoothed == null ? raw : Math.round(this.etaSmoothed * 0.6 + raw * 0.4);
         },
         onMetadataLoaded() {
             const saved = getProgress(this.$route.params.id, this.routeSeason, this.routeEpisode);
@@ -254,6 +272,7 @@ export default {
             this.$nextTick(() => {
                 this.ready = false; this.streamUrl = null; this.error = null;
                 this.subtitles = { en: null, fr: null };
+                this.etaSmoothed = null;
                 this.startPrepare();
                 this.loadSubtitles();
             });
@@ -272,7 +291,10 @@ export default {
 .btn-back { position: fixed; top: 20px; left: 20px; z-index: 100; display: flex; align-items: center; gap: 8px; background: rgba(0,0,0,0.6); border: none; border-radius: 4px; color: #fff; padding: 10px 18px; font-size: 0.9rem; cursor: pointer; transition: background 0.2s; }
 .btn-back:hover { background: rgba(255,255,255,0.15); }
 
-.player-loading { flex: 1; display: flex; align-items: center; justify-content: center; }
+.player-loading { flex: 1; display: flex; align-items: center; justify-content: center; position: relative; overflow: hidden; }
+.loading-backdrop { position: absolute; inset: 0; background-size: cover; background-position: center; filter: blur(20px) brightness(0.35); transform: scale(1.1); z-index: 0; }
+.loading-scrim { position: absolute; inset: 0; background: radial-gradient(ellipse at center, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.85) 80%); z-index: 1; }
+.loading-progress, .loading-error { position: relative; z-index: 2; }
 .loading-error { display: flex; flex-direction: column; align-items: center; gap: 16px; color: #999; }
 .loading-error p { font-size: 1rem; max-width: 400px; text-align: center; }
 .btn-retry { background: #E50914; color: #fff; border: none; border-radius: 4px; padding: 10px 24px; font-weight: 700; cursor: pointer; }

--- a/server/src/routers/movie.js
+++ b/server/src/routers/movie.js
@@ -250,6 +250,13 @@ router.get('/categories', async (req, res) => {
     }
 });
 
+const DEFAULT_BUFFER_TARGET = 2 * 1024 * 1024;
+
+function computeBufferTarget(fileSize) {
+    // Mirror the readiness threshold used in getOrCreateSession's progressInterval
+    return fileSize > 0 ? Math.min(DEFAULT_BUFFER_TARGET, fileSize * 0.02) : DEFAULT_BUFFER_TARGET;
+}
+
 // Start preparing a stream (call before /stream to pre-buffer)
 router.get('/prepare/:id', async (req, res) => {
     try {
@@ -268,6 +275,7 @@ router.get('/prepare/:id', async (req, res) => {
             speedFormatted: formatBytes(session.speed) + '/s',
             peers: session.peers,
             fileName: session.fileName,
+            bufferTarget: computeBufferTarget(session.fileSize),
             error: session.error || null,
         });
     } catch (e) {


### PR DESCRIPTION
- Warm up torrent on detail page: when a user lands on /movie/:id we fire /prepare in the background (targeting the resume point if any, else the first episode), so by the time they hit Play the torrent already has peers and pre-buffer bytes.
- Cover backdrop during buffering: the loading screen now uses a blurred+dimmed version of the movie cover instead of pure black, so the wait feels anchored to the title being loaded.
- Humanized ETA: /prepare returns bufferTarget and the player shows "Starting in ~Xs" (exponentially smoothed to avoid flicker), falling back to "Finding peers..." until at least one peer is connected.