### PR TITLE
feat: same-origin deploy — relative client URLs, nginx proxy, hardene…

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Open http://localhost:8080 in your browser.
 docker compose up --build
 ```
 
+This starts Mongo, the server, and an nginx-served client in one shot. The client container reverse-proxies API calls to the server, so everything runs on a single origin (`http://localhost:8080`) — no CORS setup needed. If `server/.env` is present its values are picked up; otherwise the server falls back to built-in defaults (no OMDB key = no catalog enrichment).
+
 ---
 
 ## Server management

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,3 +1,7 @@
 node_modules
 npm-debug.log
 dist
+.git
+*.log
+.vscode
+.idea

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -3,12 +3,13 @@ FROM node:20-alpine AS build
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci
+RUN npm ci --legacy-peer-deps
 
 COPY . .
 RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/client/build/build.js
+++ b/client/build/build.js
@@ -3,39 +3,32 @@ require('./check-versions')()
 
 process.env.NODE_ENV = 'production'
 
-const ora = require('ora')
-const rm = require('rimraf')
 const path = require('path')
-const chalk = require('chalk')
+const { rimrafSync } = require('rimraf')
 const webpack = require('webpack')
 const config = require('../config')
 const webpackConfig = require('./webpack.prod.conf')
 
-const spinner = ora('building for production...')
-spinner.start()
+console.log('building for production...')
 
-rm(path.join(config.build.assetsRoot, config.build.assetsSubDirectory), err => {
+rimrafSync(path.join(config.build.assetsRoot, config.build.assetsSubDirectory))
+
+webpack(webpackConfig, (err, stats) => {
   if (err) throw err
-  webpack(webpackConfig, (err, stats) => {
-    spinner.stop()
-    if (err) throw err
-    process.stdout.write(stats.toString({
-      colors: true,
-      modules: false,
-      children: false, // If you are using ts-loader, setting this to true will make TypeScript errors show up during build.
-      chunks: false,
-      chunkModules: false
-    }) + '\n\n')
+  process.stdout.write(stats.toString({
+    colors: true,
+    modules: false,
+    children: false,
+    chunks: false,
+    chunkModules: false,
+  }) + '\n\n')
 
-    if (stats.hasErrors()) {
-      console.log(chalk.red('  Build failed with errors.\n'))
-      process.exit(1)
-    }
+  if (stats.hasErrors()) {
+    console.log('\n  Build failed with errors.\n')
+    process.exit(1)
+  }
 
-    console.log(chalk.cyan('  Build complete.\n'))
-    console.log(chalk.yellow(
-      '  Tip: built files are meant to be served over an HTTP server.\n' +
-      '  Opening index.html over file:// won\'t work.\n'
-    ))
-  })
+  console.log('\n  Build complete.\n')
+  console.log('  Tip: built files are meant to be served over an HTTP server.')
+  console.log('  Opening index.html over file:// won\'t work.\n')
 })

--- a/client/build/check-versions.js
+++ b/client/build/check-versions.js
@@ -1,8 +1,6 @@
 'use strict'
-const chalk = require('chalk')
 const semver = require('semver')
 const packageConfig = require('../package.json')
-const shell = require('shelljs')
 
 function exec (cmd) {
   return require('child_process').execSync(cmd).toString().trim()
@@ -12,42 +10,27 @@ const versionRequirements = [
   {
     name: 'node',
     currentVersion: semver.clean(process.version),
-    versionRequirement: packageConfig.engines.node
-  }
-]
-
-if (shell.which('npm')) {
-  versionRequirements.push({
+    versionRequirement: packageConfig.engines.node,
+  },
+  {
     name: 'npm',
     currentVersion: exec('npm --version'),
-    versionRequirement: packageConfig.engines.npm
-  })
-}
+    versionRequirement: packageConfig.engines.npm,
+  },
+]
 
 module.exports = function () {
   const warnings = []
 
-  for (let i = 0; i < versionRequirements.length; i++) {
-    const mod = versionRequirements[i]
-
+  for (const mod of versionRequirements) {
     if (!semver.satisfies(mod.currentVersion, mod.versionRequirement)) {
-      warnings.push(mod.name + ': ' +
-        chalk.red(mod.currentVersion) + ' should be ' +
-        chalk.green(mod.versionRequirement)
-      )
+      warnings.push(`${mod.name}: ${mod.currentVersion} should be ${mod.versionRequirement}`)
     }
   }
 
   if (warnings.length) {
-    console.log('')
-    console.log(chalk.yellow('To use this template, you must update following to modules:'))
-    console.log()
-
-    for (let i = 0; i < warnings.length; i++) {
-      const warning = warnings[i]
-      console.log('  ' + warning)
-    }
-
+    console.log('\nTo use this template, you must update the following modules:\n')
+    for (const warning of warnings) console.log('  ' + warning)
     console.log()
     process.exit(1)
   }

--- a/client/config/dev.env.js
+++ b/client/config/dev.env.js
@@ -3,5 +3,6 @@ const { merge } = require('webpack-merge')
 const prodEnv = require('./prod.env')
 
 module.exports = merge(prodEnv, {
-  NODE_ENV: '"development"'
+  NODE_ENV: '"development"',
+  API_BASE_URL: JSON.stringify(process.env.API_BASE_URL || '')
 })

--- a/client/config/index.js
+++ b/client/config/index.js
@@ -10,7 +10,19 @@ module.exports = {
     // Paths
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',
-    proxyTable: [],
+
+    // Proxy API calls to the server in dev so the client can use relative URLs.
+    // Override target with API_PROXY_TARGET env var (e.g. when server runs in Docker).
+    proxyTable: [
+      {
+        context: [
+          '/movies', '/search', '/movie', '/prepare', '/stream',
+          '/subtitles', '/subtitles-file', '/categories', '/comment'
+        ],
+        target: process.env.API_PROXY_TARGET || 'http://localhost:8081',
+        changeOrigin: true,
+      },
+    ],
 
     // Various Dev Server settings
     host: 'localhost', // can be overwritten by process.env.HOST

--- a/client/config/prod.env.js
+++ b/client/config/prod.env.js
@@ -1,4 +1,5 @@
 'use strict'
 module.exports = {
-  NODE_ENV: '"production"'
+  NODE_ENV: '"production"',
+  API_BASE_URL: JSON.stringify(process.env.API_BASE_URL || '')
 }

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,37 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA: unknown paths fall back to index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Video + subtitles stream straight through — no buffering, long timeouts.
+    location ~ ^/(stream|subtitles-file)/ {
+        proxy_pass http://server:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+    }
+
+    # Regular API routes
+    location ~ ^/(movies|search|movie|prepare|subtitles|categories|comment)(/|$) {
+        proxy_pass http://server:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/client/src/components/VideoPlayer.vue
+++ b/client/src/components/VideoPlayer.vue
@@ -92,7 +92,7 @@ export default {
             error: null,
             streamUrl: null,
             subtitles: { en: null, fr: null },
-            apiBase: 'http://localhost:8081',
+            apiBase: process.env.API_BASE_URL || '',
             pollTimer: null,
             showNextOverlay: false,
             nextCountdown: 10,

--- a/client/src/services/Api.js
+++ b/client/src/services/Api.js
@@ -2,6 +2,6 @@ import axios from 'axios';
 
 export default () => {
     return axios.create({
-        baseURL: 'http://localhost:8081',
+        baseURL: process.env.API_BASE_URL || '',
     });
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,45 @@
-version: '3.8'
-
 services:
   mongo:
     image: mongo:7
+    restart: unless-stopped
     ports:
       - '27017:27017'
     volumes:
       - mongo-data:/data/db
+    healthcheck:
+      test: ['CMD', 'mongosh', '--quiet', '--eval', "db.adminCommand('ping').ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
 
   server:
     build: ./server
-    ports:
-      - '8081:8081'
+    restart: unless-stopped
+    # Server is reached from the browser through the nginx client container on :8080.
+    # Uncomment to expose it directly on the host for debugging.
+    # ports:
+    #   - '8081:8081'
+    expose:
+      - '8081'
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
+    env_file:
+      - path: ./server/.env
+        required: false
     environment:
       - NODE_ENV=production
       - MONGODB_URI=mongodb://mongo:27017/hypertube
+      - PORT=8081
+      # Same-origin via nginx in the client container — no cross-origin calls from the browser.
+      - CORS_ORIGINS=http://localhost:8080
+    volumes:
+      - server-downloads:/app/downloads
 
   client:
     build: ./client
+    restart: unless-stopped
     ports:
       - '8080:80'
     depends_on:
@@ -27,3 +47,4 @@ services:
 
 volumes:
   mongo-data:
+  server-downloads:

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,3 +1,8 @@
 node_modules
 npm-debug.log
 .env
+downloads
+.git
+*.log
+.vscode
+.idea


### PR DESCRIPTION
…d compose

Drop hardcoded http://localhost:8081 from the client. Api.js and VideoPlayer now read API_BASE_URL from the webpack-injected env (default empty), so the browser issues relative requests that a reverse proxy can forward to the server. This fixes the app in any non-dev deployment without a CORS dance.

Dev: webpack-dev-server proxies /movies, /search, /movie, /prepare, /stream, /subtitles, /subtitles-file, /categories and /comment to localhost:8081 (override with API_PROXY_TARGET).

Prod: new client/nginx.conf serves the SPA and proxies the same paths to server:8081 over the compose network, with proxy_buffering off and 1h timeouts on /stream + /subtitles-file so range streaming isn't buffered.

docker-compose.yml: add mongo healthcheck so server waits for a real ready signal; add server-downloads volume so torrent cache survives rebuilds; add env_file with required:false so missing server/.env doesn't error; stop binding server:8081 on the host by default (reachable via nginx on :8080, matches the same-origin model, avoids port conflicts); drop the obsolete compose 'version' key; add restart:unless-stopped across the board.

Collateral fixes needed to make the docker image actually build:
- client Dockerfile: npm ci --legacy-peer-deps (friendly-errors-webpack- plugin@1.7.0 declares a peer range that predates webpack 5)
- client/build/build.js and check-versions.js: drop chalk@5 and ora@8, which are ESM-only and were being required as CJS