### PR TITLE
feat: rate limiting, subtitle path traversal fix, session TTL

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^17.4.0",
         "download": "^8.0.0",
         "express": "^5.0.0",
+        "express-rate-limit": "^8.4.1",
         "imdb-api": "^4.0.3",
         "joi": "^18.0.0",
         "mime": "^4.0.0",
@@ -4322,6 +4323,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/content-disposition": {

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "dotenv": "^17.4.0",
     "download": "^8.0.0",
     "express": "^5.0.0",
+    "express-rate-limit": "^8.4.1",
     "imdb-api": "^4.0.3",
     "joi": "^18.0.0",
     "mime": "^4.0.0",

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -10,9 +10,15 @@ const TorrentSearchService = require('./services/TorrentSearchService');
 const { startContinuousSeeding, enrichSeriesEpisodes } = require('./config/setup');
 const movieRouter = require('./routers/movie');
 const commentRouter = require('./routers/comment');
+const { apiLimiter } = require('./middleware/rateLimit');
+
+// Behind nginx — trust a single proxy hop so req.ip reflects the real client
+// (required for accurate per-IP rate limiting via X-Forwarded-For).
+app.set('trust proxy', 1);
 
 app.use(morgan('combined'));
 app.use(bodyParser.json());
+app.use(apiLimiter);
 
 // CORS: restrict to known origins
 const allowedOrigins = (process.env.CORS_ORIGINS || 'http://localhost:8080').split(',');

--- a/server/src/middleware/rateLimit.js
+++ b/server/src/middleware/rateLimit.js
@@ -1,0 +1,24 @@
+const rateLimit = require('express-rate-limit');
+
+// Generous global limiter — applied to all routes. Sized to accommodate
+// browsers issuing many Range requests against /stream during playback.
+const apiLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 1500,
+    standardHeaders: 'draft-7',
+    legacyHeaders: false,
+    message: { error: 'Too many requests, please slow down.' },
+});
+
+// Tight limiter for endpoints that hit external APIs or spawn torrent
+// sessions (search, prepare, subtitles). Each call is expensive and easy
+// to abuse to exhaust OMDB quota or peer connections.
+const expensiveLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 30,
+    standardHeaders: 'draft-7',
+    legacyHeaders: false,
+    message: { error: 'Too many requests for this endpoint, please wait.' },
+});
+
+module.exports = { apiLimiter, expensiveLimiter };

--- a/server/src/routers/movie.js
+++ b/server/src/routers/movie.js
@@ -12,6 +12,9 @@ const Movie = require('../models/Movie');
 const { showMovie } = require('../functions/movie');
 const { enrichOneSeries } = require('../config/setup');
 const ImdbService = require('../services/ImdbService');
+const { expensiveLimiter } = require('../middleware/rateLimit');
+
+const SUBTITLES_DIR = path.resolve(__dirname, 'subtitles');
 
 const OpenSubtitles = new OS({
     useragent: Config.opensubtitles.useragent,
@@ -22,6 +25,39 @@ const OpenSubtitles = new OS({
 
 // Active torrent sessions — keyed by movie ID
 const sessions = new Map();
+
+// Idle session eviction — drop torrent engines that haven't been touched
+// in a while so a long-running PM2 process doesn't grow unbounded.
+const SESSION_IDLE_MS = 30 * 60 * 1000; // 30 minutes
+const SESSION_SWEEP_MS = 5 * 60 * 1000;  // 5 minutes
+
+function touchSession(session) {
+    session.lastAccess = Date.now();
+}
+
+function destroySession(sessionKey, session) {
+    if (session.progressInterval) {
+        clearInterval(session.progressInterval);
+        session.progressInterval = null;
+    }
+    if (session.engine) {
+        try { session.engine.destroy(); } catch (e) {}
+        session.engine = null;
+    }
+    sessions.delete(sessionKey);
+}
+
+function sweepIdleSessions() {
+    const cutoff = Date.now() - SESSION_IDLE_MS;
+    for (const [key, session] of sessions) {
+        if ((session.lastAccess || 0) < cutoff) {
+            destroySession(key, session);
+            console.log(`Evicted idle session: ${key}`);
+        }
+    }
+}
+
+setInterval(sweepIdleSessions, SESSION_SWEEP_MS).unref();
 
 // Public trackers for faster peer discovery
 const TRACKERS = [
@@ -77,7 +113,9 @@ async function getOrCreateSession(movieId, seasonNum, episodeNum, quality) {
         : movieId;
 
     if (sessions.has(sessionKey)) {
-        return sessions.get(sessionKey);
+        const existing = sessions.get(sessionKey);
+        touchSession(existing);
+        return existing;
     }
 
     const movie = await Movie.findById(movieId);
@@ -98,6 +136,8 @@ async function getOrCreateSession(movieId, seasonNum, episodeNum, quality) {
                 peers: 0,
                 progress: 1,
                 movie,
+                lastAccess: Date.now(),
+                progressInterval: null,
             };
             sessions.set(sessionKey, session);
             return session;
@@ -130,6 +170,8 @@ async function getOrCreateSession(movieId, seasonNum, episodeNum, quality) {
         peers: 0,
         progress: 0,
         movie,
+        lastAccess: Date.now(),
+        progressInterval: null,
     };
     sessions.set(sessionKey, session);
 
@@ -178,9 +220,10 @@ async function getOrCreateSession(movieId, seasonNum, episodeNum, quality) {
 
     // Track download progress
     let lastBytes = 0;
-    const progressInterval = setInterval(() => {
+    session.progressInterval = setInterval(() => {
         if (!session.engine || session.status === 'ready' || session.status === 'error') {
-            clearInterval(progressInterval);
+            clearInterval(session.progressInterval);
+            session.progressInterval = null;
             return;
         }
         const swarm = engine.swarm;
@@ -258,7 +301,7 @@ function computeBufferTarget(fileSize) {
 }
 
 // Start preparing a stream (call before /stream to pre-buffer)
-router.get('/prepare/:id', async (req, res) => {
+router.get('/prepare/:id', expensiveLimiter, async (req, res) => {
     try {
         const seasonNum = req.query.season != null ? Number(req.query.season) : undefined;
         const episodeNum = req.query.episode != null ? Number(req.query.episode) : undefined;
@@ -392,7 +435,7 @@ router.get('/movie/:id', async (req, res) => {
     }
 });
 
-router.get('/subtitles/:id', async (req, res) => {
+router.get('/subtitles/:id', expensiveLimiter, async (req, res) => {
     try {
         const movie = await Movie.findById(req.params.id);
         const season = req.query.season != null ? Number(req.query.season) : undefined;
@@ -453,7 +496,19 @@ router.get('/subtitles/:id', async (req, res) => {
 });
 
 router.get('/subtitles-file/:filename', (req, res) => {
-    const filePath = path.join(__dirname, 'subtitles', req.params.filename);
+    // Strip directory components and only serve .vtt out of SUBTITLES_DIR.
+    // path.basename + extension allowlist + a final containment check defends
+    // against `../`, encoded traversal, and absolute-path tricks.
+    const safeName = path.basename(req.params.filename);
+    if (path.extname(safeName).toLowerCase() !== '.vtt') {
+        return res.status(400).json({ error: 'Invalid subtitle filename' });
+    }
+
+    const filePath = path.resolve(SUBTITLES_DIR, safeName);
+    if (!filePath.startsWith(SUBTITLES_DIR + path.sep)) {
+        return res.status(400).json({ error: 'Invalid subtitle filename' });
+    }
+
     if (fs.existsSync(filePath)) {
         res.setHeader('Content-Type', 'text/vtt');
         fs.createReadStream(filePath).pipe(res);

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -1,8 +1,9 @@
 const MovieController = require('./controllers/MovieController');
 const SearchController = require('./controllers/SearchController');
+const { expensiveLimiter } = require('./middleware/rateLimit');
 
 module.exports = (app) => {
     app.get('/movies', MovieController.MoviesIndex);
 
-    app.get('/search', SearchController.search);
+    app.get('/search', expensiveLimiter, SearchController.search);
 };


### PR DESCRIPTION
- Add express-rate-limit with global (1500/15min) and strict (30/min) limiters; strict limiter guards /search, /prepare, /subtitles to protect OMDB quota and torrent session creation.
- Set trust proxy: 1 so per-IP limits work behind nginx.
- Harden /subtitles-file/:filename: basename + .vtt allowlist + containment check against the resolved subtitles directory.
- Evict idle torrent sessions after 30min of inactivity (5min sweep) to bound memory on long-running PM2 processes; destroy the engine and clear the progress interval on eviction.