### PR TITLE
feat: helmet security headers and Range request validation

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,6 +16,7 @@
         "download": "^8.0.0",
         "express": "^5.0.0",
         "express-rate-limit": "^8.4.1",
+        "helmet": "^8.1.0",
         "imdb-api": "^4.0.3",
         "joi": "^18.0.0",
         "mime": "^4.0.0",
@@ -5146,6 +5147,15 @@
       "license": "MIT/X11",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-escaper": {

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
     "download": "^8.0.0",
     "express": "^5.0.0",
     "express-rate-limit": "^8.4.1",
+    "helmet": "^8.1.0",
     "imdb-api": "^4.0.3",
     "joi": "^18.0.0",
     "mime": "^4.0.0",

--- a/server/src/__tests__/parseRange.test.js
+++ b/server/src/__tests__/parseRange.test.js
@@ -1,0 +1,35 @@
+const { parseRange } = require('../functions/movie');
+
+describe('parseRange', () => {
+    const SIZE = 1000;
+
+    it('parses bytes=0-499', () => {
+        expect(parseRange('bytes=0-499', SIZE)).toEqual({ start: 0, end: 499 });
+    });
+
+    it('treats open-ended range as the rest of the file', () => {
+        expect(parseRange('bytes=500-', SIZE)).toEqual({ start: 500, end: 999 });
+    });
+
+    it('clamps end past file size to size-1', () => {
+        expect(parseRange('bytes=0-9999', SIZE)).toEqual({ start: 0, end: 999 });
+    });
+
+    it('rejects malformed range headers', () => {
+        expect(parseRange('bytes=abc-def', SIZE)).toBeNull();
+        expect(parseRange('items=0-100', SIZE)).toBeNull();
+        expect(parseRange('bytes=0-100,200-300', SIZE)).toBeNull();
+    });
+
+    it('rejects suffix ranges', () => {
+        expect(parseRange('bytes=-100', SIZE)).toBeNull();
+    });
+
+    it('rejects start past file size', () => {
+        expect(parseRange('bytes=1000-1100', SIZE)).toBeNull();
+    });
+
+    it('rejects end before start', () => {
+        expect(parseRange('bytes=500-200', SIZE)).toBeNull();
+    });
+});

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const bodyParser = require('body-parser');
 const cors = require('cors');
+const helmet = require('helmet');
 const morgan = require('morgan');
 const mongoose = require('mongoose');
 const Config = require('./config/Config');
@@ -16,6 +17,10 @@ const { apiLimiter } = require('./middleware/rateLimit');
 // (required for accurate per-IP rate limiting via X-Forwarded-For).
 app.set('trust proxy', 1);
 
+// Disable CSP at the API layer — this server returns JSON, video, and VTT
+// (no HTML), so a CSP here adds noise without protection. The CSP that
+// matters is set by nginx on the SPA's index.html.
+app.use(helmet({ contentSecurityPolicy: false }));
 app.use(morgan('combined'));
 app.use(bodyParser.json());
 app.use(apiLimiter);

--- a/server/src/functions/movie.js
+++ b/server/src/functions/movie.js
@@ -1,16 +1,38 @@
 const fs = require('fs');
 const pump = require('pump');
 
+// Reject malformed/unsatisfiable Range headers with 416 instead of letting
+// NaN start/end propagate into the response. Suffix ranges (`bytes=-N`) are
+// not supported — clients that send them will get 416 and can retry without.
+function parseRange(rangeHeader, size) {
+    const match = /^bytes=(\d+)-(\d*)$/.exec(rangeHeader);
+    if (!match) return null;
+
+    const start = parseInt(match[1], 10);
+    let end = match[2] === '' ? size - 1 : parseInt(match[2], 10);
+
+    if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+    if (start < 0 || start >= size || end < start) return null;
+
+    if (end >= size) end = size - 1;
+    return { start, end };
+}
+
 const showMovie = (req, res, size, mimeType, streamSource) => {
     let start = 0;
     let end = size - 1;
 
     if (req.headers.range) {
-        const bytes = req.headers.range.replace(/bytes=/, '').split('-');
-        start = parseInt(bytes[0], 10);
-        if (bytes[1]) {
-            end = parseInt(bytes[1], 10);
+        const range = parseRange(req.headers.range, size);
+        if (!range) {
+            res.writeHead(416, {
+                'Content-Range': `bytes */${size}`,
+                'Content-Type': 'text/plain',
+            });
+            return res.end('Range Not Satisfiable');
         }
+        start = range.start;
+        end = range.end;
         res.writeHead(206, {
             'Content-Range': `bytes ${start}-${end}/${size}`,
             'Accept-Ranges': 'bytes',
@@ -36,4 +58,4 @@ const showMovie = (req, res, size, mimeType, streamSource) => {
     }
 };
 
-module.exports = { showMovie };
+module.exports = { showMovie, parseRange };


### PR DESCRIPTION
- Add helmet middleware with default headers (clickjacking, MIME sniff, etc.); CSP disabled here since this server returns JSON, video, and VTT — the meaningful CSP belongs on the SPA's index.html served by nginx.
- Validate the Range header in showMovie via a strict regex; reject malformed or unsatisfiable ranges with 416 + Content-Range so NaN start/end can no longer propagate into the response.
- Clamp open-ended ranges (bytes=N-) to size-1.
- Add jest coverage for parseRange (happy path, clamping, rejects).